### PR TITLE
Add created_by to Failure entity and user filter dropdown in UI

### DIFF
--- a/client/src/components/UpdateFailurePage.jsx
+++ b/client/src/components/UpdateFailurePage.jsx
@@ -11,6 +11,7 @@ export default function UpdateFailurePage() {
     failLevel: 'moderate',
     context: '',
     submittedBy: '',
+    created_by: '',
   });
   const [error, setError] = useState(null);
 
@@ -88,6 +89,16 @@ export default function UpdateFailurePage() {
                 type="text"
                 name="submittedBy"
                 value={formData.submittedBy}
+                onChange={handleChange}
+                required
+              />
+            </div>
+            <div className="form-group">
+              <label>Created By</label>
+              <input
+                type="text"
+                name="created_by"
+                value={formData.created_by}
                 onChange={handleChange}
                 required
               />

--- a/server/failure.model.js
+++ b/server/failure.model.js
@@ -22,6 +22,10 @@ const failureSchema = new mongoose.Schema({
     type: String,
     required: true,
   },
+  created_by: {
+    type: String,
+    required: true,
+  },
   timestamp: {
     type: Date,
     default: Date.now,


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added `created_by` field to Failure entity and validation logic

- Enhanced backend validation for new and updated failures

- Implemented user-based filtering of failures in UI

- Updated forms to support and display `created_by` field


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>failure.model.js</strong><dd><code>Add `created_by` field to Failure schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/failure.model.js

<li>Added <code>created_by</code> field to the Failure schema<br> <li> Made <code>created_by</code> a required string property


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S84_list_of_autocorret_failures/pull/15/files#diff-651bcbd384484598872c0ea7ad35d18c86581fdd3cf43fcc09aed8e1d2b05cb1">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>routes.js</strong><dd><code>Enhance validation to include `created_by` and stricter checks</code></dd></summary>
<hr>

server/routes.js

<li>Extended validation middleware to require <code>created_by</code><br> <li> Added string trimming and length checks for all fields<br> <li> Improved error messages for missing or invalid fields<br> <li> Ensured sanitized data is attached to request body


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S84_list_of_autocorret_failures/pull/15/files#diff-97f32ef3bfee3f436316e1eba5d4b1aac4ad25bbb9a0d15fec233716c6efd81c">+47/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>App.jsx</strong><dd><code>Add user filter and handle `created_by` in failures UI</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/App.jsx

<li>Added state and logic for user-based filtering of failures<br> <li> Populated user dropdown from unique <code>created_by</code> values<br> <li> Updated add-failure form to set <code>created_by</code><br> <li> Displayed filtered failures based on selected user


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S84_list_of_autocorret_failures/pull/15/files#diff-51b002bf85fbd146b38871b89ba0d41c2bead37756295748c67206aac23ddc9a">+48/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>UpdateFailurePage.jsx</strong><dd><code>Support editing `created_by` in update failure form</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/components/UpdateFailurePage.jsx

<li>Added <code>created_by</code> field to form state and UI<br> <li> Allowed editing of <code>created_by</code> when updating a failure


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S84_list_of_autocorret_failures/pull/15/files#diff-5da4063f5ada6360ebd6a476e80f78ea1ac8a6817fd3966f3ba10bfbbc947b88">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>